### PR TITLE
Add catch all route on server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5868,6 +5868,15 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "0.11.10",
+        "util": "0.10.3"
+      }
+    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -6570,8 +6579,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -7992,7 +8000,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.1"
       },
@@ -8000,8 +8007,7 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/geogopher/geogopher#readme",
   "dependencies": {
     "express": "^4.16.2",
+    "path": "^0.12.7",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",

--- a/server/server.js
+++ b/server/server.js
@@ -1,10 +1,13 @@
 const express = require('express');
 const webpack = require('webpack');
+const path = require('path');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 
 const app = express();
 const config = require('../webpack.dev.js');
 const compiler = webpack(config);
+
+const apiRouter = express.Router();
 
 app.use(webpackDevMiddleware(compiler, {
   publicPath: config.output.publicPath
@@ -12,9 +15,20 @@ app.use(webpackDevMiddleware(compiler, {
 
 app.use(express.static('../dist'));
 
+app.get('/*', (req, res) => {
+  res.sendFile(path.resolve('./dist', 'index.html'));
+});
+
 app.listen(1337, function () {
   console.log('😎 listening on 1337')
 });
+
+app.use('/api', apiRouter);
+
+apiRouter.route('/map')
+  .get((req, res) => {
+    res.send('hello')
+  })
 
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ export default class App extends React.Component {
       <div>
         <nav>
             <NavLink exact to="/" > home </NavLink>
-            <NavLink to="/map" > map </NavLink>
+            <NavLink to="/map"> map </NavLink>
         </nav>
         <Container></Container>
       </div>

--- a/src/Components/Container.jsx
+++ b/src/Components/Container.jsx
@@ -8,8 +8,8 @@ class Container extends React.Component {
     render() {
       return (
         <main>
-            <Route exact path="/" component={ Home }/>
-            <Route path="/map" component={ Map }/>
+          <Route path="/map" component={Map}/>
+          <Route exact path="/" component={Home}/>
         </main>
       );
     }

--- a/src/Components/Map.jsx
+++ b/src/Components/Map.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 let map;
+const google = window.google;
 
 export default class Map extends React.Component {
   constructor(props){
@@ -13,12 +14,12 @@ export default class Map extends React.Component {
   }
 
   componentDidMount(){
-    map = new window.google.maps.Map(document.getElementById('map'),{
+    map = new google.maps.Map(document.getElementById('map'),{
       zoom: 2,
       center: {lat: 30, lng: 31},
       zoomControl: true,
       zoomControlOptions: {
-        position: window.google.maps.ControlPosition.RIGHT_CENTER
+        position: google.maps.ControlPosition.RIGHT_CENTER
       },
       streetViewControl: false,
       mapTypeControl: false,

--- a/src/Components/Map.jsx
+++ b/src/Components/Map.jsx
@@ -1,7 +1,7 @@
+/*global window.google*/
 import React from 'react';
 
 let map;
-const google = window.google;
 
 export default class Map extends React.Component {
   constructor(props){
@@ -14,12 +14,12 @@ export default class Map extends React.Component {
   }
 
   componentDidMount(){
-    map = new google.maps.Map(document.getElementById('map'),{
+    map = new window.google.maps.Map(document.getElementById('map'),{
       zoom: 2,
       center: {lat: 30, lng: 31},
       zoomControl: true,
       zoomControlOptions: {
-        position: google.maps.ControlPosition.RIGHT_CENTER
+        position: window.google.maps.ControlPosition.RIGHT_CENTER
       },
       streetViewControl: false,
       mapTypeControl: false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter as Router} from 'react-router-dom';
 import store from './store';
 import { Provider } from 'react-redux';
 
 import App from './App';
 
 ReactDOM.render(<Provider store={store}>
-        <BrowserRouter>
+        <Router>
           <App />
-        </BrowserRouter>
+        </Router>
       </Provider>, document.getElementById('app'));


### PR DESCRIPTION
Now you can type in a url and see a route. However, this is done by server side rendering. Because of that, there is no "window" object. So if you go to the /map route by typing in the browser bar, no map will render. This is not an issue with the router. We need to find a different way to load google maps.