### PR TITLE
Sound toggle working. Geoclick has one round delay.

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -78,7 +78,6 @@ export default class Map extends React.Component {
       userQuit: false,
       renderMissingCountriesButton: false,
       renderSkipCountryButton: false,
-      // renderSoundButton: true,
       renderInputField: true,
       gameType: true,
       gameDifficulty: false,

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -78,6 +78,7 @@ export default class Map extends React.Component {
       userQuit: false,
       renderMissingCountriesButton: false,
       renderSkipCountryButton: false,
+      // renderSoundButton: true,
       renderInputField: true,
       gameType: true,
       gameDifficulty: false,
@@ -88,6 +89,7 @@ export default class Map extends React.Component {
       currentHint: null,
       skipInProgress: false,
       hintInProgress: false,
+      currentSoundState: true,
       geoClickPolygonDisplay: '',
       oneStepBack: {
         gameType: true,
@@ -264,7 +266,6 @@ export default class Map extends React.Component {
 
   //on start focus client cursor to answerInput field and start timer?
   handleStart() {
-
     //pack gameValues for game init
     let gameValues = {
       map: map,
@@ -278,6 +279,7 @@ export default class Map extends React.Component {
       highlightedPolygon: this.state.highlightedPolygon,
       handleGameEnd: this.handleGameEnd,
       gameSelected: this.props.gameSelected,
+      currentSoundState: this.state.currentSoundState,
       refs: this.refs
     }
     if (this.props.gameTypeSelected !== 'GEOCLICK') {
@@ -428,6 +430,7 @@ export default class Map extends React.Component {
         reactThis: this,
         highlightedPolygon: this.state.highlightedPolygon,
         handleGameEnd: this.handleGameEnd,
+        currentSoundState: this.state.currentSoundState,
         refs: this.refs,
       }
 
@@ -598,6 +601,7 @@ export default class Map extends React.Component {
       highlightedPolygon: this.state.highlightedPolygon,
       handleGameEnd: this.handleGameEnd,
       gameSelected: this.props.gameSelected,
+      currentSoundState: this.state.currentSoundState,
       refs: this.refs
     }
 
@@ -643,18 +647,25 @@ export default class Map extends React.Component {
       handleGameEnd: this.handleGameEnd,
       countPolygonsEntered: this.props.countPolygonsEntered,
       gameSelected: this.props.gameSelected,
+      currentSoundState: this.state.currentSoundState,
       refs: this.refs
     }
 
     if (this.props.gameTypeSelected === 'GEOCLICK') {
-
       if (!google.maps.event.hasListeners(map.data, 'click')) {
         geoClickGameLogic(gameValues, this.state.highlightedPolygon)
       }
-
     } else {
       this.nameInput.focus();
     }
+  }
+
+/** Sound toggle */
+  toggleSoundState = (e) => {
+    this.state.currentSoundState ?
+    this.setState({ currentSoundState: false} ) :
+    this.setState({ currentSoundState: true} )
+    this.props.gameTypeSelected !== 'GEOCLICK' ? this.nameInput.focus() : null
   }
 
   render() {
@@ -716,6 +727,16 @@ export default class Map extends React.Component {
           }
 
           <div className="polygon-score"> {this.props.countPolygonsEntered}/{this.props.maxCountPolygons} </div>
+
+        { /** Sound toggle button */
+          <div className="sound-btn">
+            SOUND&nbsp;
+            <Checkbox
+              checked={ this.state.currentSoundState }
+              onClick={ this.toggleSoundState }toggle
+            />
+          </div>
+        }
 
           {
             this.state.currentHint !== null

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -610,7 +610,7 @@ div.game-controls{
                          ".. .. ..       ..       ..        ..        .."
                          ".. .. hintdisp hintdisp hintdisp  hintdisp  .."
                          ".. zi inputent inputent inputent  inputent  .."
-                         ".. zo hint     advance  ..        quit      .."
+                         ".. zo hint     advance  sound     quit      .."
                          ".. .. ..       ..       ..        ..        ..";
 
     @media screen and (max-width: 1299px) {
@@ -784,8 +784,6 @@ div.zoom-out{
   }
 }
 
-
-
 div.hint-btn{
   grid-area: hint;
   z-index: 4;
@@ -801,6 +799,27 @@ div.hint-btn{
   justify-content: center;
   &:hover{
     background-color: #008000;
+    color: white;
+    box-shadow: 5px 10px 20px -10px darkslategrey;
+    cursor: pointer;
+  }
+}
+
+div.sound-btn{
+  grid-area: sound;
+  z-index: 4;
+  background-color: white;
+  color: #FF810D;
+  border: 5px solid #FF810D;
+  font-size: 1.25em;
+  font-weight: bold;
+  padding: 2%;
+  box-shadow: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &:hover{
+    background-color: #FF810D;
     color: white;
     box-shadow: 5px 10px 20px -10px darkslategrey;
     cursor: pointer;

--- a/src/utils/countdownGameLogic.js
+++ b/src/utils/countdownGameLogic.js
@@ -59,6 +59,7 @@ const countdownAnswerResponse = (answerStatus, polygonID, gameValues) => {
   let submissionSanitized = gameValues.submissionSanitized;
   let incorrectEntries = gameValues.incorrectEntries;
   let countTotalSubmissions = gameValues.countTotalSubmissions;
+  let currentSoundState = gameValues.currentSoundState;
   let entryCorrect = gameValues.refs.entry_correct;
   let entryIncorrect = gameValues.refs.entry_incorrect;
   let entryCorrectResubmit = gameValues.refs.entry_correct_resubmit;
@@ -84,8 +85,8 @@ const countdownAnswerResponse = (answerStatus, polygonID, gameValues) => {
         strokeWeight: '2',
       }
     ), 1000);
-  //trigger for already-answered sound
-    entryCorrectResubmit.play();
+  //play already-answered sound
+    currentSoundState ?  entryCorrectResubmit.play() : null;
   } else if (answerStatus === 'unanswered') {
     //modify map to reflect answered  polygon
     map.data.overrideStyle(
@@ -106,13 +107,11 @@ const countdownAnswerResponse = (answerStatus, polygonID, gameValues) => {
         gameData
       )
     );
-    //trigger for correct sound
-    entryCorrect.play();
+    currentSoundState ?  entryCorrect.play() : null;
   } else { //answer status is 'incorrect'
     //dispatch to store in incorrectEntries
     dispatchFcn(submitIncorrectEntry(submissionSanitized, incorrectEntries));
-    //trigger for incorrect sound
-    entryIncorrect.play();
+    currentSoundState ?  entryIncorrect.play() : null;
   // TODO: trigger for text field to shake
   }
 

--- a/src/utils/geoClickGameLogic.js
+++ b/src/utils/geoClickGameLogic.js
@@ -20,20 +20,18 @@ export const geoClickGameLogic = async(gameValues, highlightedCountry, skipCount
   //declare logic variables
   let entryIncorrect = gameValues.refs.entry_incorrect;
   let entryCorrect = gameValues.refs.entry_correct;
+  let currentSoundState = gameValues.currentSoundState;
   let allowNextCountry = false;
   let moreCountriesLeft = false;
   let endGame = true;
   let featureName;
 
-
   if (skipCountry && !gameValues.skipInProgress) {
-
     //set global skipInProgress to true, to prevent double skips
     gameValues.reactThis.setState({
       skipInProgress: true
     });
-    // play an incorrect sound
-    entryIncorrect.play();
+    currentSoundState ?  entryIncorrect.play() : null;
     //get the polygon inside the map by using the id
     let polygonInMap = gameValues.map.data.getFeatureById(highlightedCountry.id)
     //modify the colors of polygon in the map to be greyed out
@@ -120,8 +118,7 @@ export const geoClickGameLogic = async(gameValues, highlightedCountry, skipCount
             strokeColor: '#7FFF00',
             strokeWeight: '2'
           })
-          // play a correct sound
-          entryCorrect.play();
+          currentSoundState ?  entryCorrect.play() : null;
           //submit correct entry
           gameValues.dispatchFcn(
             submitCorrectEntry(
@@ -133,7 +130,7 @@ export const geoClickGameLogic = async(gameValues, highlightedCountry, skipCount
           //remove all listeners on correct entry. new listeners will be created for the next polygon
           google.maps.event.clearInstanceListeners(gameValues.map.data);
         } else {
-          entryIncorrect.play();
+          currentSoundState ?  entryIncorrect.play() : null;
         }
       })
     //end callback for getRandomUnansweredPolygon

--- a/src/utils/nameTheCountryGameLogic.js
+++ b/src/utils/nameTheCountryGameLogic.js
@@ -21,6 +21,7 @@ export const nameTheCountryGameLogic = async(gameValues, highlightedCountry, ski
   const imgFromAssets = require('-!file-loader?name=markerImg!../assets/geogopher-marker.png');
   let entryIncorrect = gameValues.refs.entry_incorrect;
   let entryCorrect = gameValues.refs.entry_correct;
+  let currentSoundState = gameValues.currentSoundState;
   // if a highlighted country has not been passed in, then it came from Map's handleStart
   if (!highlightedCountry) {
     // a random polygon is returned from gameData, invoking cb using random polygon as 'highlightedCountry'
@@ -69,8 +70,7 @@ export const nameTheCountryGameLogic = async(gameValues, highlightedCountry, ski
         strokeColor: 'darkslategrey',
         strokeWeight: '2'
       })
-      // play an incorrect sound
-      entryIncorrect.play();
+      currentSoundState ?  entryIncorrect.play() : null;
       //instantiate new marker to hold info window
       let marker = new google.maps.Marker({
         map: gameValues.map,
@@ -132,8 +132,7 @@ export const nameTheCountryGameLogic = async(gameValues, highlightedCountry, ski
               el.polygonAnswered = true;
             }
           })
-          // play correct sound
-          entryCorrect.play();
+          currentSoundState ?  entryCorrect.play() : null;
         //end of if statement that matches submission to accepted answer
         }
       //end of forEach that cycles through accepted answers
@@ -161,7 +160,7 @@ export const nameTheCountryGameLogic = async(gameValues, highlightedCountry, ski
           gameValues.incorrectEntries
         )
       )
-      entryIncorrect.play();
+      currentSoundState ?  entryIncorrect.play() : null;
     }
   //end of else statement
   }


### PR DESCRIPTION
As a player, I am not always jacked up on Red Bull when I play and instead am sometimes playing a game while sipping a cup of Sleepytime tea.  Not surprisingly, when I'm playing in this latter state, I prefer quiet and solitude and really don't want to hear those dings and buzzes that tell me whether I've got the answer right or wrong.  With this in mind, as a player, I want the ability to toggle off the sound.